### PR TITLE
Fix upstream install path

### DIFF
--- a/deploy/crds/tower_v1alpha1_tower_crd.yaml
+++ b/deploy/crds/tower_v1alpha1_tower_crd.yaml
@@ -18,3 +18,16 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+  validation:
+    openAPIV3Schema:
+      description: Schema validation for the Tower CRD
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            deployment_type:
+              type: string
+              pattern: "^(tower|awx)(-)?.*$"
+          required:
+            - deployment_type

--- a/roles/tower/defaults/main.yml
+++ b/roles/tower/defaults/main.yml
@@ -40,8 +40,6 @@ tower_postgres_storage_class: ''
 
 tower_postgres_data_path: '/var/lib/postgresql/data/pgdata'
 
-uwsgi_bash: "scl enable rh-postgresql10"
-
 tower_postgres_port: 5432
 
 ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"

--- a/roles/tower/tasks/initialize.yml
+++ b/roles/tower/tasks/initialize.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if there are any Tower super users defined.
   shell: >-
-    kubectl exec -n {{ meta.namespace }} -c tower-task {{ tower_pod_name }} -- bash -c
+    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
     "echo 'from django.contrib.auth.models import User;
     nsu = User.objects.filter(is_superuser=True).count();
     exit(0 if nsu > 0 else 1)'
@@ -12,7 +12,7 @@
 
 - name: Create Tower super user via Django if it doesn't exist.
   shell: >-
-    kubectl exec -n {{ meta.namespace }} -c tower-task {{ tower_pod_name }} -- bash -c
+    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
     "echo \"from django.contrib.auth.models import User;
     User.objects.create_superuser('{{ tower_admin_user }}', '{{ tower_admin_email }}', '{{ tower_admin_password }}')\"
     | awx-manage shell"
@@ -21,7 +21,7 @@
 
 - name: Create preload data if necessary.  # noqa 305
   shell: >-
-    kubectl exec -n {{ meta.namespace }} -c tower-task {{ tower_pod_name }} -- bash -c
+    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
     "awx-manage create_preload_data"
   register: cdo
   changed_when: "'added' in cdo.stdout"

--- a/roles/tower/tasks/main.yml
+++ b/roles/tower/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include_vars: "{{ deployment_type }}.yml"
+
 - name: Ensure configured Tower resources exist in the cluster.
   k8s:
     apply: yes
@@ -33,7 +35,7 @@
 
 - name: Check if database is populated (auth_user table exists).
   shell: >-
-    kubectl exec -n {{ meta.namespace }} -c tower-task {{ tower_pod_name }} -- bash -c
+    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
     "echo 'from django.db import connection;
     tbl = \"auth_user\" in connection.introspection.table_names();
     exit(0 if tbl else 1)'
@@ -45,7 +47,7 @@
 
 - name: Migrate the database if the K8s resources were updated.  # noqa 305
   shell: >-
-    kubectl exec -n {{ meta.namespace }} -c tower-task {{ tower_pod_name }} -- bash -c
+    kubectl exec -n {{ meta.namespace }} -c {{ meta.name }}-task {{ tower_pod_name }} -- bash -c
     "awx-manage migrate --noinput"
   register: migrate_result
   when: (k8s_defs_result is changed) or (database_check is defined and database_check.rc != 0)

--- a/roles/tower/templates/tower.yaml.j2
+++ b/roles/tower/templates/tower.yaml.j2
@@ -245,7 +245,7 @@ spec:
     app: tower
 
 # Tower Ingress.
-{% if 'ingress' == tower_ingress_type %}
+{% if 'ingress' == tower_ingress_type|lower %}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -263,7 +263,7 @@ spec:
           servicePort: 80
 {% endif %}
 
-{% if 'route' == tower_ingress_type %}
+{% if 'route' == tower_ingress_type|lower %}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/roles/tower/vars/awx.yml
+++ b/roles/tower/vars/awx.yml
@@ -1,0 +1,1 @@
+uwsgi_bash: "bash -c"

--- a/roles/tower/vars/tower.yml
+++ b/roles/tower/vars/tower.yml
@@ -1,0 +1,1 @@
+uwsgi_bash: "scl enable rh-postgresql10"


### PR DESCRIPTION
Note that this added the required attribute spec.deployment_type. This _can_ go
away after the supervisor configs move back into the downstream images, but the
pattern may prove useful for other things in the future.